### PR TITLE
feat: [ENGINE-2] #comment Cloud 이슈 삭제 구현 - 23.08.09

### DIFF
--- a/src/main/java/com/arms/jira/cloud/CloudJiraUtils.java
+++ b/src/main/java/com/arms/jira/cloud/CloudJiraUtils.java
@@ -64,11 +64,34 @@ public class CloudJiraUtils {
                 .bodyToMono(responseType);
     }
 
-    public static Optional<Boolean> executePut(WebClient webClient, Object requestBody, String uri) {
+    public static Optional<Boolean> executePost(WebClient webClient, String uri, Object requestBody) {
+
+        Mono<ResponseEntity<Void>> response = webClient.post()
+                                                .uri(uri)
+                                                .body(BodyInserters.fromValue(requestBody))
+                                                .retrieve()
+                                                .toEntity(Void.class);
+
+        return response.map(entity -> entity.getStatusCode() == HttpStatus.NO_CONTENT) // 결과가 204인가 확인
+                .blockOptional();
+    }
+
+    public static Optional<Boolean> executePut(WebClient webClient, String uri, Object requestBody) {
 
         Mono<ResponseEntity<Void>> response = webClient.put()
                                                 .uri(uri)
                                                 .body(BodyInserters.fromValue(requestBody))
+                                                .retrieve()
+                                                .toEntity(Void.class);
+
+        return response.map(entity -> entity.getStatusCode() == HttpStatus.NO_CONTENT) // 결과가 204인가 확인
+                .blockOptional();
+    }
+
+    public static Optional<Boolean> executeDelete(WebClient webClient, String uri) {
+
+        Mono<ResponseEntity<Void>> response = webClient.delete()
+                                                .uri(uri)
                                                 .retrieve()
                                                 .toEntity(Void.class);
 

--- a/src/main/java/com/arms/jira/cloud/jiraissue/controller/CloudJiraIssueController.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissue/controller/CloudJiraIssueController.java
@@ -1,10 +1,8 @@
 package com.arms.jira.cloud.jiraissue.controller;
 
 
-import com.arms.jira.cloud.jiraissue.model.CloudJiraIssueDTO;
-import com.arms.jira.cloud.jiraissue.model.CloudJiraIssueInputDTO;
+import com.arms.jira.cloud.jiraissue.model.*;
 import com.arms.jira.cloud.jiraissue.service.CloudJiraIssue;
-import com.arms.jira.cloud.jiraissue.model.CloudJiraIssueSearchDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +62,7 @@ public class CloudJiraIssueController {
             method = {RequestMethod.PUT}
     )
     public Map<String,Object> updateIssueForReqAdd(@PathVariable("connectId") String connectId,
-                                                   @PathVariable String issueKeyOrId,
+                                                   @PathVariable("issueKeyOrId") String issueKeyOrId,
                                                    @RequestBody CloudJiraIssueInputDTO cloudJiraIssueInputDTO) {
         return cloudJiraIssue.updateIssue(connectId, issueKeyOrId, cloudJiraIssueInputDTO);
     }
@@ -74,11 +72,13 @@ public class CloudJiraIssueController {
             value = {"/{issueKeyOrId}"},
             method = {RequestMethod.DELETE}
     )
-    public void deleteDataToaRMS(@PathVariable("connectId") String connectId,
-                                    @PathVariable String issueKeyOrId,
+    public Map<String,Object> deleteDataToaRMS(@PathVariable("connectId") String connectId,
+                                 @PathVariable("issueKeyOrId") String issueKeyOrId,
                                  ModelMap model, HttpServletRequest request) throws Exception {
 
-        cloudJiraIssue.deleteIssue(connectId, issueKeyOrId);
+        Map<String,Object> result = cloudJiraIssue.deleteIssue(connectId, issueKeyOrId);
+
+        return result;
     }
 
     @ResponseBody
@@ -86,11 +86,51 @@ public class CloudJiraIssueController {
             value = {"/collection/scheduler"},
             method = {RequestMethod.PUT}
     )
-    public String collectLinkAndSubtask(@PathVariable("connectId") String connectId,
+    public Map<String,Object> collectLinkAndSubtask(@PathVariable("connectId") String connectId,
                              ModelMap model, HttpServletRequest request) throws Exception {
-        String result = cloudJiraIssue.collectLinkAndSubtask(connectId);
+        Map<String,Object> result = cloudJiraIssue.collectLinkAndSubtask(connectId);
 
         return result;
     }
 
+    @ResponseBody
+    @RequestMapping(
+            value = {"/add/label/{issueKeyOrId}"},
+            method = {RequestMethod.PUT}
+    )
+    public Map<String,Object> addLabel(@PathVariable("connectId") String connectId,
+                                       @PathVariable("issueKeyOrId") String issueKeyOrId,
+                                        @RequestBody IssueLabelUpdateRequestDTO issueLabelUpdateRequestDTO,
+                                                    ModelMap model, HttpServletRequest request) throws Exception {
+        Map<String,Object> result = cloudJiraIssue.addLabel(connectId, issueKeyOrId, issueLabelUpdateRequestDTO);
+
+        return result;
+    }
+
+    @ResponseBody
+    @RequestMapping(
+            value = {"/{issueKeyOrId}/transitions/list"},
+            method = {RequestMethod.GET}
+    )
+    public TransitionsDTO getIssueStatusAll(@PathVariable("connectId") String connectId,
+                                            @PathVariable("issueKeyOrId") String issueKeyOrId,
+                                            ModelMap model, HttpServletRequest request) throws Exception {
+        TransitionsDTO result = cloudJiraIssue.getIssueStatusAll(connectId, issueKeyOrId);
+
+        return result;
+    }
+
+    @ResponseBody
+    @RequestMapping(
+            value = {"/{issueKeyOrId}/transitions"},
+            method = {RequestMethod.POST}
+    )
+    public Map<String,Object> updateIssueStatus(@PathVariable("connectId") String connectId,
+                                                @PathVariable("issueKeyOrId") String issueKeyOrId,
+                                                @RequestBody IssueStatusUpdateRequestDTO issueStatusUpdateRequestDTO,
+                                                    ModelMap model, HttpServletRequest request) throws Exception {
+        Map<String,Object> result = cloudJiraIssue.updateIssueStatus(connectId, issueKeyOrId, issueStatusUpdateRequestDTO );
+
+        return result;
+    }
 }

--- a/src/main/java/com/arms/jira/cloud/jiraissue/model/IssueLabelUpdateRequestDTO.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissue/model/IssueLabelUpdateRequestDTO.java
@@ -1,0 +1,40 @@
+package com.arms.jira.cloud.jiraissue.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IssueLabelUpdateRequestDTO {
+
+    private Update update;
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Update {
+        private List<Label> labels;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Label {
+        private String add;
+    }
+}

--- a/src/main/java/com/arms/jira/cloud/jiraissue/model/IssueStatusUpdateRequestDTO.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissue/model/IssueStatusUpdateRequestDTO.java
@@ -1,0 +1,27 @@
+package com.arms.jira.cloud.jiraissue.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IssueStatusUpdateRequestDTO {
+
+    private TransitionInputDTO transition;
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class TransitionInputDTO {
+        private String id;
+    }
+}

--- a/src/main/java/com/arms/jira/cloud/jiraissue/model/TransitionsDTO.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissue/model/TransitionsDTO.java
@@ -1,0 +1,31 @@
+package com.arms.jira.cloud.jiraissue.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TransitionsDTO {
+    private String expand;
+    private List<Transitions> transitions;
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Transitions {
+        private String id;
+        private String name;
+    }
+}

--- a/src/main/java/com/arms/jira/cloud/jiraissue/service/CloudJiraIssue.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissue/service/CloudJiraIssue.java
@@ -1,8 +1,6 @@
 package com.arms.jira.cloud.jiraissue.service;
 
-import com.arms.jira.cloud.jiraissue.model.CloudJiraIssueDTO;
-import com.arms.jira.cloud.jiraissue.model.CloudJiraIssueInputDTO;
-import com.arms.jira.cloud.jiraissue.model.CloudJiraIssueSearchDTO;
+import com.arms.jira.cloud.jiraissue.model.*;
 
 import java.util.Map;
 
@@ -16,8 +14,13 @@ public interface CloudJiraIssue {
 
     public Map<String,Object> updateIssue(String connectId, String issueKeyOrId, CloudJiraIssueInputDTO cloudJiraIssueInputDTO);
 
-    public void deleteIssue(String connectId, String issueKeyOrId) throws Exception;
+    public Map<String,Object> deleteIssue(String connectId, String issueKeyOrId) throws Exception;
 
-    public String collectLinkAndSubtask(String connectId);
+    public Map<String,Object> collectLinkAndSubtask(String connectId);
 
+    public Map<String, Object> addLabel(String connectId, String issueKeyOrId, IssueLabelUpdateRequestDTO issueLabelUpdateRequestDTO);
+
+    public TransitionsDTO getIssueStatusAll(String connectId, String issueKeyOrId);
+
+    public Map<String,Object> updateIssueStatus(String connectId, String issueKeyOrId, IssueStatusUpdateRequestDTO issueStatusUpdateRequestDTO);
 }

--- a/src/main/java/com/arms/jira/cloud/jiraissue/service/CloudJiraIssueImpl.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissue/service/CloudJiraIssueImpl.java
@@ -1,11 +1,10 @@
 package com.arms.jira.cloud.jiraissue.service;
 
 import com.arms.jira.cloud.CloudJiraUtils;
+import com.arms.jira.cloud.jiraissue.dao.CloudJiraIssueJpaRepository;
 import com.arms.jira.cloud.jiraissue.model.*;
 import com.arms.jira.info.model.JiraInfoDTO;
 import com.arms.jira.info.service.JiraInfo;
-import com.arms.jira.cloud.jiraissue.dao.CloudJiraIssueJpaRepository;
-import com.arms.jira.cloud.jiraissue.model.*;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
@@ -113,7 +112,7 @@ public class CloudJiraIssueImpl implements CloudJiraIssue {
         JiraInfoDTO found = jiraInfo.loadConnectInfo(connectId);
         WebClient webClient = CloudJiraUtils.createJiraWebClient(found.getUri(), found.getUserId(), found.getPasswordOrToken());
 
-        Optional<Boolean> response = CloudJiraUtils.executePut(webClient, cloudJiraIssueInputDTO, endpoint);
+        Optional<Boolean> response = CloudJiraUtils.executePut(webClient, endpoint, cloudJiraIssueInputDTO);
 
         Map<String,Object> result = new HashMap<String,Object>();
 
@@ -139,25 +138,85 @@ public class CloudJiraIssueImpl implements CloudJiraIssue {
 
     @Transactional
     @Override
-    public void deleteIssue(String connectId, String issueKeyOrId) throws Exception {
+    public Map<String,Object> deleteIssue(String connectId, String issueKeyOrId) throws Exception {
 
-        String endpoint ="";
+        Map<String, Object> result = new HashMap<String, Object>();
+
+        String endpoint = "/rest/api/3/issue/" + issueKeyOrId +"?deleteSubtasks=false";
         JiraInfoDTO found = jiraInfo.loadConnectInfo(connectId);
         WebClient webClient = CloudJiraUtils.createJiraWebClient(found.getUri(), found.getUserId(), found.getPasswordOrToken());
 
-        if(checkSubTask(connectId, issueKeyOrId)){ //서브테스크가 있을 경유
-            for(int i=0;i<getSubTask(connectId, issueKeyOrId).size();i++){
-                convertSubtaskToIssue(connectId, String.valueOf(getSubTask(connectId, issueKeyOrId).get(i).getId()), issueKeyOrId);
+        if (checkSubTask(connectId, issueKeyOrId)){ //서브테스크가 있을 경유
+//            for (int i=0;i<getSubTask(connectId, issueKeyOrId).size();i++) {
+//                convertSubtaskToIssue(connectId, String.valueOf(getSubTask(connectId, issueKeyOrId).get(i).getId()), issueKeyOrId);
+//            }
+
+            String labelValue = "삭제처리이슈";
+            IssueLabelUpdateRequestDTO.Label label = new IssueLabelUpdateRequestDTO.Label();
+            label.setAdd(labelValue);
+
+            List<IssueLabelUpdateRequestDTO.Label> labels = new ArrayList<>();
+            labels.add(label);
+
+            IssueLabelUpdateRequestDTO.Update update = new IssueLabelUpdateRequestDTO.Update();
+            update.setLabels(labels);
+
+            IssueLabelUpdateRequestDTO issueLabelUpdateRequestDTO = new IssueLabelUpdateRequestDTO();
+            issueLabelUpdateRequestDTO.setUpdate(update);
+
+            Map<String, Object> addLabelResult = addLabel(connectId,issueKeyOrId, issueLabelUpdateRequestDTO);
+
+            if (!((Boolean) addLabelResult.get("success"))) {
+                result.put("success", false);
+                result.put("message", "이슈 라벨 추가 실패");
+                
+                return result;
             }
-            endpoint= "/rest/api/3/issue/" + issueKeyOrId +"?deleteSubtasks=true";
-        }else{
-            endpoint = "/rest/api/3/issue/" + issueKeyOrId +"?deleteSubtasks=false";
+
+            String transitionsId = "2";
+            IssueStatusUpdateRequestDTO.TransitionInputDTO transitionInputDTO = new IssueStatusUpdateRequestDTO.TransitionInputDTO();
+            transitionInputDTO.setId(transitionsId);
+        
+            IssueStatusUpdateRequestDTO issueStatusUpdateRequestDTO = new IssueStatusUpdateRequestDTO();
+            issueStatusUpdateRequestDTO.setTransition(transitionInputDTO);
+
+            Map<String, Object> updateIssueStatusResult = updateIssueStatus(connectId, issueKeyOrId, issueStatusUpdateRequestDTO);
+
+            if (!((Boolean) updateIssueStatusResult.get("success"))) {
+                result.put("success", false);
+                result.put("message", "이슈 상태 변경 실패");
+
+                return result;
+            }
+
+            if ((Boolean) addLabelResult.get("success") && (Boolean) updateIssueStatusResult.get("success")) {
+                result.put("success", true);
+                result.put("message", "서브테스크 이슈가 있으므로 이슈를 라벨 처리 및 닫기로 상태 변경 완료");
+
+                return result;
+            }
         }
 
-        CloudJiraUtils.delete(webClient, endpoint, Void.class).block();
+        Optional<Boolean> response = CloudJiraUtils.executeDelete(webClient, endpoint);
 
-        cloudJiraIssueJpaRepository.deleteById(issueKeyOrId);
+        boolean isSuccess = false;
 
+        if (response.isPresent()) {
+            if (response.get()) {
+                // PUT 호출이 HTTP 204로 성공했습니다.
+                isSuccess = true;
+                result.put("success", isSuccess);
+                result.put("message", "이슈 삭제 성공");
+                // cloudJiraIssueJpaRepository.deleteById(issueKeyOrId);
+
+                return result;
+            }
+        }
+
+        result.put("success", isSuccess);
+        result.put("message", "이슈 삭제 실패");
+
+        return result;
     }
 
     public List<CloudJiraIssueDTO> getSubTask(String connectId, String issueId){
@@ -165,10 +224,10 @@ public class CloudJiraIssueImpl implements CloudJiraIssue {
         return SubTaskList;
     }
 
-    public boolean checkSubTask(String connectId,String issueKeyOrId){
-        if(getSubTask(connectId, issueKeyOrId).size()>0){
+    public boolean checkSubTask(String connectId,String issueKeyOrId) {
+        if (getSubTask(connectId, issueKeyOrId).size()>0) {
             return true;
-        }else return false;
+        } else return false;
     }
 
     public void convertSubtaskToIssue(String connectId, String  subTaskKeyOrId,String issueKeyOrId) throws Exception {
@@ -201,7 +260,7 @@ public class CloudJiraIssueImpl implements CloudJiraIssue {
 
     @Transactional
     @Override
-    public String collectLinkAndSubtask(String connectId) {
+    public Map<String,Object> collectLinkAndSubtask(String connectId) {
         List<CloudJiraIssueEntity> list = cloudJiraIssueJpaRepository.findAll();
         List<CloudJiraIssueEntity> saveList = new ArrayList<>();
 
@@ -251,6 +310,102 @@ public class CloudJiraIssueImpl implements CloudJiraIssue {
             cloudJiraIssueJpaRepository.saveAll(saveList);
         }
 
-        return "success";
+        Map<String, Object> result = new HashMap<String, Object>();
+        result.put("success", true);
+        result.put("message", "스케줄러 작동 완료되었습니다.");
+
+        return result;
+    }
+
+    public Map<String, Object> addLabel(String connectId, String issueKeyOrId,
+                                        IssueLabelUpdateRequestDTO issueLabelUpdateRequestDTO) {
+
+        String endpoint = "/rest/api/3/issue/" + issueKeyOrId;
+
+        JiraInfoDTO found = jiraInfo.loadConnectInfo(connectId);
+        WebClient webClient = CloudJiraUtils.createJiraWebClient(found.getUri(), found.getUserId(), found.getPasswordOrToken());
+
+//        IssueLabelUpdateRequestDTO.Label label = new IssueLabelUpdateRequestDTO.Label();
+//        label.setAdd(labelValue);
+//
+//        List<IssueLabelUpdateRequestDTO.Label> labels = new ArrayList<>();
+//        labels.add(label);
+//
+//        IssueLabelUpdateRequestDTO.Update update = new IssueLabelUpdateRequestDTO.Update();
+//        update.setLabels(labels);
+//
+//        IssueLabelUpdateRequestDTO issueLabelUpdateRequestDTO = new IssueLabelUpdateRequestDTO();
+//        issueLabelUpdateRequestDTO.setUpdate(update);
+
+        Optional<Boolean> response = CloudJiraUtils.executePut(webClient, endpoint, issueLabelUpdateRequestDTO);
+
+        Map<String,Object> result = new HashMap<String,Object>();
+
+        boolean isSuccess = false;
+
+        if (response.isPresent()) {
+            if (response.get()) {
+                // PUT 호출이 HTTP 204로 성공했습니다.
+                isSuccess = true;
+                result.put("success", isSuccess);
+                result.put("message", "이슈 라벨 추가 성공");
+
+                return result;
+            }
+        }
+
+        result.put("success", isSuccess);
+        result.put("message", "이슈 라벨 추가 실패");
+
+        return result;
+    }
+
+    public TransitionsDTO getIssueStatusAll(String connectId, String issueKeyOrId) {
+
+        String endpoint = "/rest/api/3/issue/" + issueKeyOrId +"/transitions";
+
+        JiraInfoDTO found = jiraInfo.loadConnectInfo(connectId);
+        WebClient webClient = CloudJiraUtils.createJiraWebClient(found.getUri(), found.getUserId(), found.getPasswordOrToken());
+
+        TransitionsDTO transitions = CloudJiraUtils.get(webClient, endpoint, TransitionsDTO.class).block();
+
+        return transitions;
+    }
+
+    public Map<String,Object> updateIssueStatus(String connectId, String issueKeyOrId,
+                                                IssueStatusUpdateRequestDTO issueStatusUpdateRequestDTO) {
+
+        String endpoint = "/rest/api/3/issue/" + issueKeyOrId +"/transitions";
+
+        JiraInfoDTO found = jiraInfo.loadConnectInfo(connectId);
+        WebClient webClient = CloudJiraUtils.createJiraWebClient(found.getUri(), found.getUserId(), found.getPasswordOrToken());
+
+//        IssueStatusUpdateRequestDTO.TransitionInputDTO transitionInputDTO = new IssueStatusUpdateRequestDTO.TransitionInputDTO();
+//        transitionInputDTO.setId(transitionsId);
+//
+//        IssueStatusUpdateRequestDTO issueStatusUpdateRequestDTO = new IssueStatusUpdateRequestDTO();
+//        issueStatusUpdateRequestDTO.setTransition(transitionInputDTO);
+
+        Optional<Boolean> response = CloudJiraUtils.executePost(webClient, endpoint, issueStatusUpdateRequestDTO);
+
+        Map<String,Object> result = new HashMap<String,Object>();
+
+        boolean isSuccess = false;
+
+        if (response.isPresent()) {
+            if (response.get()) {
+                // PUT 호출이 HTTP 204로 성공했습니다.
+                isSuccess = true;
+                result.put("success", isSuccess);
+                result.put("message", "이슈 상태 수정 성공");
+
+                return result;
+            }
+        }
+
+        result.put("success", isSuccess);
+        result.put("message", "이슈 상태 수정 실패");
+
+        return result;
     }
 }

--- a/src/main/java/com/arms/jira/cloud/jiraissuetypescheme/service/CloudJiraIssueTypeSchemeImpl.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissuetypescheme/service/CloudJiraIssueTypeSchemeImpl.java
@@ -121,7 +121,7 @@ public class CloudJiraIssueTypeSchemeImpl implements CloudJiraIssueTypeScheme {
         JiraInfoDTO found = jiraInfo.loadConnectInfo(connectId);
         WebClient webClient = CloudJiraUtils.createJiraWebClient(found.getUri(), found.getUserId(), found.getPasswordOrToken());
 
-        Optional<Boolean> result = CloudJiraUtils.executePut(webClient, dto, endpoint);
+        Optional<Boolean> result = CloudJiraUtils.executePut(webClient, endpoint, dto);
 
         // Mono<Void> addIssueTypeScheme = CloudJiraUtils.put(webClient, endpoint, dto, Void.class);
         // try {

--- a/src/main/java/com/arms/jira/onpremise/jiraissuetype/service/OnPremiseJiraIssueTypeImpl.java
+++ b/src/main/java/com/arms/jira/onpremise/jiraissuetype/service/OnPremiseJiraIssueTypeImpl.java
@@ -52,9 +52,9 @@ public class OnPremiseJiraIssueTypeImpl implements OnPremiseJiraIssueType{
                 .findFirst().orElse(null); // 결과가 없으면 null을 반환합니다.
 
         if (result != null) {
-            System.out.println("찾은 IssueType: " + result);
+            logger.info("찾은 IssueType: " + result);
         } else {
-            System.out.println("ID가 " + issueTypeId + "인 IssueType을 찾을 수 없습니다.");
+            logger.info("ID가 " + issueTypeId + "인 IssueType을 찾을 수 없습니다.");
         }
 
         logger.info(result.toString());


### PR DESCRIPTION
1. 서브테스크 있을 시 - 라벨에 삭제처리라고 추가 후 이슈 닫힘으로 변경
2. 서브테스크 없을 시 - 삭제 처리

위 기능을 위해
이슈의 상태값을 조회 api 추가 / 이슈의 상태값 변경 api 추가 / 이슈 라벨 추가 api 추가 / 변경, 추가를 위한 DTO 추가

#close #time 1h +review SR @313devops

[ Backend-Core::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/