### PR TITLE
feat: [JIRA-9] #comment 온프레미스 이슈 삭제 기능 추가 - 23.08.10

### DIFF
--- a/src/main/java/com/arms/jira/cloud/jiraissue/service/CloudJiraIssueImpl.java
+++ b/src/main/java/com/arms/jira/cloud/jiraissue/service/CloudJiraIssueImpl.java
@@ -43,7 +43,7 @@ public class CloudJiraIssueImpl implements CloudJiraIssue {
         JiraInfoDTO found = jiraInfo.loadConnectInfo(connectId);
         WebClient webClient = CloudJiraUtils.createJiraWebClient(found.getUri(), found.getUserId(), found.getPasswordOrToken());
 
-        CloudJiraIssueSearchDTO cloudJiraIssueSearchDTO = null;
+        CloudJiraIssueSearchDTO cloudJiraIssueSearchDTO = new CloudJiraIssueSearchDTO();
         List<CloudJiraIssueDTO> issueList = new ArrayList<>(); // 이슈 저장
 
         while (!isLast) {
@@ -230,7 +230,7 @@ public class CloudJiraIssueImpl implements CloudJiraIssue {
         } else return false;
     }
 
-    public void convertSubtaskToIssue(String connectId, String  subTaskKeyOrId,String issueKeyOrId) throws Exception {
+    public void convertSubtaskToIssue(String connectId, String subTaskKeyOrId,String issueKeyOrId) throws Exception {
 
         CloudJiraIssueDTO issue = getIssue(connectId, subTaskKeyOrId);
         String issueTypeId      = getIssue(connectId, issueKeyOrId).getFields().getIssuetype().getId();

--- a/src/main/java/com/arms/jira/onpremise/jiraissue/controller/OnPremiseJiraIssueController.java
+++ b/src/main/java/com/arms/jira/onpremise/jiraissue/controller/OnPremiseJiraIssueController.java
@@ -69,5 +69,17 @@ public class OnPremiseJiraIssueController {
         logger.info("이슈 업데이트 API 호출");
         return onPremiseJiraIssue.updateIssue(connectId, issueKeyOrId, onPremiseJiraIssueInputDTO);
     }
-    //삭제
+
+    // 이슈 삭제
+    @ResponseBody
+    @RequestMapping(
+            value = {"/{issueKey}"},
+            method = {RequestMethod.DELETE}
+    )
+    public Map<String, Object> deleteIssue(@PathVariable("connectId") String connectId,
+                                           @PathVariable String issueKey) throws Exception {
+        logger.info("이슈 삭제 API 호출");
+        return onPremiseJiraIssue.deleteIssue(connectId, issueKey);
+    }
+
 }

--- a/src/main/java/com/arms/jira/onpremise/jiraissue/service/OnPremiseJiraIssue.java
+++ b/src/main/java/com/arms/jira/onpremise/jiraissue/service/OnPremiseJiraIssue.java
@@ -5,15 +5,12 @@ import com.arms.jira.onpremise.jiraissue.model.OnPremiseJiraIssueInputDTO;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
 
-
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Map;
 public interface OnPremiseJiraIssue {
 
 
     // 이슈 생성
-    public OnPremiseJiraIssueDTO createIssue(String connectId, OnPremiseJiraIssueInputDTO onPremiseJiraIssueInputDTO) throws Exception;
+    OnPremiseJiraIssueDTO createIssue(String connectId, OnPremiseJiraIssueInputDTO onPremiseJiraIssueInputDTO) throws Exception;
 
     // 프로젝트 이슈 조회
     SearchResult getIssueSearch(String connectId, String projectKeyOrId) throws Exception;
@@ -24,5 +21,6 @@ public interface OnPremiseJiraIssue {
     // 이슈 업데이트
     Map<String, Object> updateIssue(String connectId, String issueKeyOrId, OnPremiseJiraIssueInputDTO onPremiseJiraIssueInputDTO) throws Exception;
 
-
+    // 이슈 삭제
+    Map<String, Object> deleteIssue(String connectId, String issueKey) throws Exception;
 }

--- a/src/main/java/com/arms/jira/onpremise/jiraissue/service/OnPremiseJiraIssueImpl.java
+++ b/src/main/java/com/arms/jira/onpremise/jiraissue/service/OnPremiseJiraIssueImpl.java
@@ -9,9 +9,11 @@ import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
+import com.atlassian.jira.rest.client.api.domain.Transition;
 import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
+import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
@@ -20,8 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.*;
 
 @AllArgsConstructor
@@ -91,8 +91,8 @@ public class OnPremiseJiraIssueImpl implements OnPremiseJiraIssue {
     public SearchResult getIssueSearch(String connectId, String projectKeyOrId) throws Exception {
         JiraInfoDTO info = jiraInfo.loadConnectInfo(connectId);
         JiraRestClient restClient = OnPremiseJiraUtils.getJiraRestClient(info.getUri(),
-                info.getUserId(),
-                info.getPasswordOrToken());
+                                                                         info.getUserId(),
+                                                                         info.getPasswordOrToken());
 
         String jql = "project = " + projectKeyOrId;
         int maxResults = 10;
@@ -124,44 +124,120 @@ public class OnPremiseJiraIssueImpl implements OnPremiseJiraIssue {
     public Map<String, Object> updateIssue(String connectId, String issueKeyOrId, OnPremiseJiraIssueInputDTO onPremiseJiraIssueInputDTO) throws Exception {
         Map<String, Object> resultMap = new HashMap<>();
         try {
-        JiraInfoDTO info = jiraInfo.loadConnectInfo(connectId);
-        JiraRestClient restClient = OnPremiseJiraUtils.getJiraRestClient(info.getUri(),
-                info.getUserId(),
-                info.getPasswordOrToken());
+            JiraInfoDTO info = jiraInfo.loadConnectInfo(connectId);
+            JiraRestClient restClient = OnPremiseJiraUtils.getJiraRestClient(info.getUri(),
+                                                                             info.getUserId(),
+                                                                             info.getPasswordOrToken());
 
-        FieldsDTO fields = onPremiseJiraIssueInputDTO.getFields();
+            FieldsDTO fields = onPremiseJiraIssueInputDTO.getFields();
 
-        IssueInputBuilder issueInputBuilder = new IssueInputBuilder();
+            IssueInputBuilder issueInputBuilder = new IssueInputBuilder();
 
-        // summary,description,Priority 업데이트 개발 완료
-        if (fields.getSummary() != null) { //요약
-            issueInputBuilder.setSummary(fields.getSummary());
-        }
-        if (fields.getDescription() != null) { // 설명
-            issueInputBuilder.setDescription(fields.getDescription());
-        }
+            // summary,description,Priority 업데이트 개발 완료
+            if (fields.getSummary() != null) { //요약
+                issueInputBuilder.setSummary(fields.getSummary());
+            }
+            if (fields.getDescription() != null) { // 설명
+                issueInputBuilder.setDescription(fields.getDescription());
+            }
 
-        if (fields.getPriority() != null && fields.getPriority().getId() != null) {//우선순위
-            issueInputBuilder.setFieldValue("priority", ComplexIssueInputFieldValue.with("id", fields.getPriority().getId()));
-        }
+            if (fields.getPriority() != null && fields.getPriority().getId() != null) {//우선순위
+                issueInputBuilder.setFieldValue("priority", ComplexIssueInputFieldValue.with("id", fields.getPriority().getId()));
+            }
 
-//        if (fields.getAssignee() != null && fields.getAssignee().getName() != null) { //담당자
-//            issueInputBuilder.setAssigneeName(fields.getAssignee().getName());
-//        }
-//        if (fields.getReporter() != null && fields.getReporter().getName() != null) { //보고자
-//            issueInputBuilder.setReporterName(fields.getReporter().getName());
-//        }
-        IssueInput issueInput = issueInputBuilder.build();
+            if (fields.getLabels().size() != 0) {
+                issueInputBuilder.setFieldValue("labels", fields.getLabels());
+            }
 
-        // 이슈 업데이트 실행
-        restClient.getIssueClient().updateIssue(issueKeyOrId, issueInput).claim();
-        resultMap.put("updateStatus", "success");
-        return resultMap;
+    //        if (fields.getAssignee() != null && fields.getAssignee().getName() != null) { //담당자
+    //            issueInputBuilder.setAssigneeName(fields.getAssignee().getName());
+    //        }
+    //        if (fields.getReporter() != null && fields.getReporter().getName() != null) { //보고자
+    //            issueInputBuilder.setReporterName(fields.getReporter().getName());
+    //        }
+            IssueInput issueInput = issueInputBuilder.build();
+
+            // 이슈 업데이트 실행
+            restClient.getIssueClient().updateIssue(issueKeyOrId, issueInput).claim();
+            resultMap.put("updateStatus", "success");
+            return resultMap;
         } catch (Exception e) { // 업데이트 실패한 경우
             resultMap.put("updateStatus", "failed");
             resultMap.put("errorMessage", e.getMessage());
         }
         return resultMap;
     }
+
+    @Override
+    public Map<String, Object> deleteIssue(String connectId, String issueKey) throws Exception {
+        JiraInfoDTO info = jiraInfo.loadConnectInfo(connectId);
+        JiraRestClient restClient = OnPremiseJiraUtils.getJiraRestClient(info.getUri(),
+                                                                         info.getUserId(),
+                                                                         info.getPasswordOrToken());
+
+        // 서브 테스크가 있는지 체크
+        // 서브 테스크가 있다면 라벨링 및 이슈 닫기
+        // 서브 테스크가 없다면 삭제
+        Map<String, Object> result = new HashMap<String, Object>();
+        Issue issue = getIssue(connectId, issueKey);
+        String closeIssue = "close issue";
+
+        // 서브 테스크 존재 여부 체크
+        if (issue.getSubtasks().iterator().hasNext()) { // 서브 테스크 있는 경우
+            logger.info("서브 테스크가 존재합니다.");
+
+            // 라벨링
+            String closedLabel = "closedIssue";
+
+            FieldsDTO fieldsDTO = new FieldsDTO();
+            fieldsDTO.setLabels(List.of(closedLabel));
+
+            OnPremiseJiraIssueInputDTO onPremiseJiraIssueInputDTO = new OnPremiseJiraIssueInputDTO();
+            onPremiseJiraIssueInputDTO.setFields(fieldsDTO);
+
+            Map<String, Object> addLabel = updateIssue(connectId, issueKey, onPremiseJiraIssueInputDTO);
+            if ("success".equals(addLabel.get("updateStatus"))) {
+                result.put("add label success", "라벨링 성공");
+                logger.info("서브 테스크가 존재하는 이슈 라벨링에 성공하였습니다.");
+            } else {
+                result.put("add label fail", "라벨링 실패");
+                logger.info("서브 테스크가 존재하는 이슈 라벨링에 실패하였습니다.");
+            }
+
+            // 이슈 닫기
+            List<Transition> transitions = (List<Transition>) restClient.getIssueClient().getTransitions(issue).claim();
+            Transition closeTransition = transitions.stream()
+                    .filter(transition -> transition.getName().equalsIgnoreCase(closeIssue))
+                    .findFirst()
+                    .orElse(null);
+
+            if (closeTransition != null) {
+                try {
+                    TransitionInput transitionInput = new TransitionInput(closeTransition.getId());
+                    restClient.getIssueClient().transition(issue, transitionInput).claim();
+                    result.put("close issue success", "이슈 닫기 성공");
+                    logger.info("서브 테스크가 존재하는 이슈 닫기에 성공하였습니다.");
+                } catch (Exception e) {
+                    result.put("close issue fail", "이슈 닫기 실패");
+                    logger.info("서브 테스크가 존재하는 이슈 닫기에 실패하였습니다.");
+                }
+            }
+        } else {
+            logger.info("서브 테스크가 존재하지 않습니다.");
+
+            boolean deleteSubtasks = false;
+            try {
+                restClient.getIssueClient().deleteIssue(issueKey, deleteSubtasks).claim();
+                result.put("delete issue success", "이슈 삭제 성공");
+                logger.info("서브 테스크가 존재하지 않는 이슈를 삭제하였습니다.");
+            } catch (Exception e) {
+                result.put("delete issue fail", "이슈 삭제 실패");
+                logger.info("서브 테스크가 존재하지 않는 이슈를 삭제에 실패하였습니다.");
+            }
+        }
+
+        return result;
+    }
+
 
 }


### PR DESCRIPTION
1. 서브 테스크 있으면, 라벨링 및 이슈 닫기
2. 서브 테스크 없으면, 이슈 삭제
3. 이슈 업데이트 시, 라벨 추가 #close #time 1h +review SR @313devops

[ Backend-Core::Java-Service-Tree-Framework(JSTF)::ssoohyun ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/