### PR TITLE
:see_no_evil: refactor: [ENGINE] #comment 삭제된 이슈 조회 시 exception처리 제거  - 23.09.03

### DIFF
--- a/src/main/java/com/arms/elasticsearch/services/지라이슈_검색엔진.java
+++ b/src/main/java/com/arms/elasticsearch/services/지라이슈_검색엔진.java
@@ -8,7 +8,10 @@ import com.arms.elasticsearch.util.검색엔진_유틸;
 import com.arms.elasticsearch.util.검색조건;
 import com.arms.errors.codes.에러코드;
 import com.arms.jira.jiraissue.model.지라이슈_데이터;
+import com.arms.jira.jiraissue.model.지라이슈필드_데이터;
+import com.arms.jira.jiraissue.model.지라프로젝트_데이터;
 import com.arms.jira.jiraissue.service.지라이슈_전략_호출;
+import com.arms.jira.jiraissuestatus.model.지라이슈상태_데이터;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.search.SearchRequest;
@@ -119,9 +122,9 @@ public class 지라이슈_검색엔진 implements 지라이슈_서비스{
         return 검색엔진_유틸.특정필드_검색후_다른필드_그룹결과(인덱스이름, 특정필드, 특정필드검색어, 그룹할필드 );
     }
 
-
     @Override
     public int 이슈_링크드이슈_서브테스크_벌크로_추가하기(Long 지라서버_아이디, String 이슈_키 , Long 제품서비스_아이디, Long 제품서비스_버전) throws Exception {
+
         long beforeTime = System.currentTimeMillis(); //코드 실행 전에 시간 받아오기
 
         if (지라서버_아이디 == null) {
@@ -141,30 +144,70 @@ public class 지라이슈_검색엔진 implements 지라이슈_서비스{
 
         List<지라이슈> 벌크_저장_목록 = new ArrayList<지라이슈>();
 
-        지라이슈_데이터 받아온_이슈 = 지라이슈_전략_호출.이슈_상세정보_가져오기(지라서버_아이디, 이슈_키);
-        지라이슈 저장할_요구사항_이슈 = ELK_데이터로_변환(지라서버_아이디, 받아온_이슈,
-                true, "", 제품서비스_아이디, 제품서비스_버전);
+        지라이슈_데이터 반환된_이슈 = Optional.ofNullable(지라이슈_전략_호출.이슈_상세정보_가져오기(지라서버_아이디, 이슈_키))
+                .map(이슈 -> {
+                    벌크_저장_목록.add(ELK_데이터로_변환(지라서버_아이디, 이슈, true, "", 제품서비스_아이디, 제품서비스_버전));
+                    return 이슈;
+                }).orElse(null);
 
-        벌크_저장_목록.add(저장할_요구사항_이슈);
+        if (반환된_이슈 == null) {
 
-        List<지라이슈_데이터> 받아온_이슈링크_목록 = 지라이슈_전략_호출.이슈링크_가져오기(지라서버_아이디, 이슈_키);
-        List<지라이슈_데이터> 받아온_서브테스크_목록 = 지라이슈_전략_호출.서브테스크_가져오기(지라서버_아이디, 이슈_키);
+            반환된_이슈 = new 지라이슈_데이터();
 
-        List<지라이슈_데이터> 이슈링크_또는_서브테스크_목록 = new ArrayList<지라이슈_데이터>();
+            반환된_이슈.setKey(이슈_키);
 
-        이슈링크_또는_서브테스크_목록.addAll(받아온_이슈링크_목록);
-        이슈링크_또는_서브테스크_목록.addAll(받아온_서브테스크_목록);
+            String 프로젝트_키 = 이슈_키.substring(0, 이슈_키.indexOf("-"));
 
-        List<지라이슈> 이슈링크_또는_서브테스크 = 이슈링크_또는_서브테스크_목록.stream()
-                .map(이슈링크또는서브테스크 -> ELK_데이터로_변환(지라서버_아이디, 이슈링크또는서브테스크,
-                                    false, 이슈_키, 제품서비스_아이디, 제품서비스_버전))
-                .collect(Collectors.toList());
+            지라프로젝트_데이터 지라프로젝트_데이터 = new 지라프로젝트_데이터();
+            지라프로젝트_데이터.setKey(프로젝트_키);
 
-        벌크_저장_목록.addAll(이슈링크_또는_서브테스크);
+            지라이슈상태_데이터 지라이슈상태_데이터 = new 지라이슈상태_데이터();
+            지라이슈상태_데이터.setId("해당 요구사항은 지라서버에서 조회가 되지 않는 상태입니다.");
+            지라이슈상태_데이터.setSelf("해당 요구사항은 지라서버에서 조회가 되지 않는 상태입니다.");
+            지라이슈상태_데이터.setName("해당 요구사항은 지라서버에서 조회가 되지 않는 상태입니다.");
+            지라이슈상태_데이터.setDescription("해당 요구사항은 지라서버에서 조회가 되지 않는 상태입니다.");
+
+            지라이슈필드_데이터 지라이슈필드_데이터 = new 지라이슈필드_데이터();
+
+            지라이슈필드_데이터.setProject(지라프로젝트_데이터);
+            지라이슈필드_데이터.setStatus(지라이슈상태_데이터);
+
+            반환된_이슈.setFields(지라이슈필드_데이터);
+
+            벌크_저장_목록.add(ELK_데이터로_변환(지라서버_아이디, 반환된_이슈, true, "", 제품서비스_아이디, 제품서비스_버전));
+        }
+        else {
+
+            List<지라이슈_데이터> 이슈링크_또는_서브테스크_목록 = new ArrayList<지라이슈_데이터>();
+
+            Optional.ofNullable(지라이슈_전략_호출.이슈링크_가져오기(지라서버_아이디, 이슈_키))
+                    .map(이슈링크_목록 -> {
+                        이슈링크_또는_서브테스크_목록.addAll(이슈링크_목록);
+                        return 이슈링크_목록;
+                    });
+
+            Optional.ofNullable(지라이슈_전략_호출.서브테스크_가져오기(지라서버_아이디, 이슈_키))
+                    .map(서브테스크_목록 -> {
+                        이슈링크_또는_서브테스크_목록.addAll(서브테스크_목록);
+                        return 서브테스크_목록;
+                    });
+
+            if (이슈링크_또는_서브테스크_목록 != null || 이슈링크_또는_서브테스크_목록.size() < 1) {
+                이슈링크_또는_서브테스크_목록.stream().map(이슈링크또는서브테스크 -> {
+                            지라이슈 변환된_이슈 = ELK_데이터로_변환(지라서버_아이디, 이슈링크또는서브테스크,
+                                    false, 이슈_키, 제품서비스_아이디, 제품서비스_버전);
+                            벌크_저장_목록.add(변환된_이슈);
+                            return 변환된_이슈;
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+            }
+        }
 
         long afterTime = System.currentTimeMillis(); // 코드 실행 후에 시간 받아오기
-        long secDiffTime = (afterTime - beforeTime)/1000; //두 시간에 차 계산
-        System.out.println("시간차이(m) : "+secDiffTime);
+        long secDiffTime = (afterTime - beforeTime) / 1000; //두 시간에 차 계산
+        System.out.println("시간차이(m) : " + secDiffTime);
+
         return 대량이슈_추가하기(벌크_저장_목록);
     }
 
@@ -275,9 +318,9 @@ public class 지라이슈_검색엔진 implements 지라이슈_서비스{
 
         지라이슈 이슈 = 지라이슈.builder()
                 .jira_server_id(지라서버_아이디)
-                .issueID(지라이슈_데이터.getId().toString())
-                .key(지라이슈_데이터.getKey())
-                .self(지라이슈_데이터.getSelf())
+                .issueID(Optional.ofNullable(지라이슈_데이터.getId()).orElse(null))
+                .key(Optional.ofNullable(지라이슈_데이터.getKey()).orElse(null))
+                .self(Optional.ofNullable(지라이슈_데이터.getSelf()).orElse(null))
                 .parentReqKey(부모_요구사항_키)
                 .isReq(요구사항유형_여부)
                 .project(프로젝트)
@@ -285,15 +328,15 @@ public class 지라이슈_검색엔진 implements 지라이슈_서비스{
                 .creator(생성자)
                 .reporter(보고자)
                 .assignee(담당자)
-                .labels(지라이슈_데이터.getFields().getLabels())
+                .labels(Optional.ofNullable(지라이슈_데이터.getFields().getLabels()).orElse(null))
                 .priority(우선순위)
                 .status(상태)
                 .resolution(해결책)
-                .resolutiondate(지라이슈_데이터.getFields().getResolutiondate())
-                .created(지라이슈_데이터.getFields().getCreated())
+                .resolutiondate(Optional.ofNullable(지라이슈_데이터.getFields().getResolutiondate()).orElse(null))
+                .created(Optional.ofNullable(지라이슈_데이터.getFields().getCreated()).orElse(null))
                 .worklogs(워크로그)
-                .timespent(지라이슈_데이터.getFields().getTimespent())
-                .summary(지라이슈_데이터.getFields().getSummary())
+                .timespent(Optional.ofNullable(지라이슈_데이터.getFields().getTimespent()).orElse(null))
+                .summary(Optional.ofNullable(지라이슈_데이터.getFields().getSummary()).orElse(null))
                 .pdServiceId(제품서비스_아이디)
                 .pdServiceVersion(제품서비스_버전)
                 .build();

--- a/src/main/java/com/arms/jira/jiraissue/strategy/클라우드_지라이슈_전략.java
+++ b/src/main/java/com/arms/jira/jiraissue/strategy/클라우드_지라이슈_전략.java
@@ -98,9 +98,9 @@ public class 클라우드_지라이슈_전략 implements 지라이슈_전략 {
             로그.info(지라이슈_데이터.toString());
 
             return 지라이슈_데이터;
-        }catch (Exception e){
-            로그.error("클라우드 이슈 조회시 오류가 발생하였습니다.");
-            throw new IllegalArgumentException(에러코드.이슈_조회_오류.getErrorMsg());
+        } catch (Exception e) {
+            로그.error("이슈 정보 가져오기에 실패하였습니다. 조회 대상 정보 확인이 필요합니다.");
+            return null;
         }
     }
 
@@ -353,7 +353,7 @@ public class 클라우드_지라이슈_전략 implements 지라이슈_전략 {
                 .build();
     }
 
-    public List<지라이슈_데이터> 이슈링크_가져오기(Long 연결_아이디, String 이슈_키_또는_아이디){
+    public List<지라이슈_데이터> 이슈링크_가져오기(Long 연결_아이디, String 이슈_키_또는_아이디) {
 
         로그.info("클라우드 이슈 링크 가져오기");
 
@@ -366,26 +366,33 @@ public class 클라우드_지라이슈_전략 implements 지라이슈_전략 {
 
         List<지라이슈_데이터> 이슈링크_목록 = new ArrayList<>(); // 이슈 저장
 
-        while (!isLast) {
-            String endpoint = "/rest/api/3/search?jql=issue in linkedIssues(" + 이슈_키_또는_아이디 + ")&" + 지라유틸.조회할_필드_목록_가져오기()
-                    + "&startAt=" + 검색_시작_지점 + "&maxResults=" + 최대_검색수;
+        try {
+            while (!isLast) {
+                String endpoint = "/rest/api/3/search?jql=issue in linkedIssues(" + 이슈_키_또는_아이디 + ")&" + 지라유틸.조회할_필드_목록_가져오기()
+                        + "&startAt=" + 검색_시작_지점 + "&maxResults=" + 최대_검색수;
 
-            지라이슈조회_데이터 이슈링크_조회결과
-                    = 지라유틸.get(webClient, endpoint, 지라이슈조회_데이터.class).block();
+                지라이슈조회_데이터 이슈링크_조회결과
+                        = 지라유틸.get(webClient, endpoint, 지라이슈조회_데이터.class).block();
 
-            이슈링크_목록.addAll(이슈링크_조회결과.getIssues());
+                이슈링크_목록.addAll(이슈링크_조회결과.getIssues());
 
-            if (이슈링크_조회결과.getTotal() == 이슈링크_목록.size()) {
-                isLast = true;
-            }else{
-                검색_시작_지점 += 최대_검색수;
+                if (이슈링크_조회결과.getTotal() == 이슈링크_목록.size()) {
+                    isLast = true;
+                } else {
+                    검색_시작_지점 += 최대_검색수;
+                }
             }
+
+            System.out.println(이슈링크_목록.toString());
+
+            return 이슈링크_목록;
         }
-
-        System.out.println(이슈링크_목록.toString());
-
-        return 이슈링크_목록;
+        catch (Exception e) {
+            로그.error("조회하려는 이슈 키의 연결된 이슈 정보 가져오기에 실패하였습니다. 조회 대상 정보 확인이 필요합니다.");
+            return null;
+        }
     }
+
     public List<지라이슈_데이터> 서브테스크_가져오기(Long 연결_아이디, String 이슈_키_또는_아이디) {
 
         로그.info("클라우드 서브테스크 가져오기");
@@ -398,27 +405,32 @@ public class 클라우드_지라이슈_전략 implements 지라이슈_전략 {
 
         List<지라이슈_데이터> 서브테스크_목록 = new ArrayList<>(); // 이슈 저장
 
-        while (!isLast) {
-            String endpoint = "/rest/api/3/search?jql=parent="+ 이슈_키_또는_아이디 +
-                                "&" + 지라유틸.조회할_필드_목록_가져오기() +
-                                "&startAt=" + 검색_시작_지점 + "&maxResults=" + 최대_검색수;
+        try {
+            while (!isLast) {
+                String endpoint = "/rest/api/3/search?jql=parent=" + 이슈_키_또는_아이디 +
+                        "&" + 지라유틸.조회할_필드_목록_가져오기() +
+                        "&startAt=" + 검색_시작_지점 + "&maxResults=" + 최대_검색수;
 
-            지라이슈조회_데이터 서브테스크_조회결과
-                    = 지라유틸.get(webClient, endpoint, 지라이슈조회_데이터.class).block();
+                지라이슈조회_데이터 서브테스크_조회결과
+                        = 지라유틸.get(webClient, endpoint, 지라이슈조회_데이터.class).block();
 
-            서브테스크_목록.addAll(서브테스크_조회결과.getIssues());
+                서브테스크_목록.addAll(서브테스크_조회결과.getIssues());
 
-            if (서브테스크_조회결과.getTotal() == 서브테스크_목록.size()) {
-                isLast = true;
-            }else{
-                검색_시작_지점 += 최대_검색수;
+                if (서브테스크_조회결과.getTotal() == 서브테스크_목록.size()) {
+                    isLast = true;
+                } else {
+                    검색_시작_지점 += 최대_검색수;
+                }
             }
+
+            System.out.println(서브테스크_목록.toString());
+
+            return 서브테스크_목록;
         }
-
-        System.out.println(서브테스크_목록.toString());
-
-        return 서브테스크_목록;
-
+        catch (Exception e) {
+            로그.error("조회하려는 이슈 키의 서브테스크 정보 가져오기에 실패하였습니다. 조회 대상 정보 확인이 필요합니다.");
+            return null;
+        }
     }
 
     public List<지라이슈워크로그_데이터> 이슈_워크로그_조회(WebClient webClient, String 이슈_키_또는_아이디) {


### PR DESCRIPTION
삭제된 이슈 조회 시 exception처리 제거 
-> null 처리 후 해당 이슈 status 데이터를 모두 "해당 요구사항은 지라서버에서 조회가 되지 않는 상태입니다."로 변경 후 elk로 저장 시킴
이 때 parentReqKey가 삭제된 이슈일 경우도 이렇게 변경해야할 지 여부에 대한 판단이 필요

#close #time 1h +review SR @313devops

[ Backend-Core::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/