### PR TITLE
:see_no_evil: test: [ENGINE] #comment RestHighLevelClient 미사용 백업인덱스 저장 로직 변경 - 23.12.19

### DIFF
--- a/src/main/java/com/arms/elasticsearch/helper/인덱스_유틸.java
+++ b/src/main/java/com/arms/elasticsearch/helper/인덱스_유틸.java
@@ -165,7 +165,7 @@ public class 인덱스_유틸 {
         return false;
     }
 
-    private boolean 인덱스_존재_확인(String 인덱스명) {
+    public boolean 인덱스_존재_확인(String 인덱스명) {
         IndexOperations 인덱스작업 = 엘라스틱서치_작업.indexOps(IndexCoordinates.of(인덱스명));
         return 인덱스작업.exists();
     }

--- a/src/main/java/com/arms/elasticsearch/util/repository/공통저장소.java
+++ b/src/main/java/com/arms/elasticsearch/util/repository/공통저장소.java
@@ -19,9 +19,13 @@ public interface 공통저장소<T,ID extends Serializable> extends Elasticsearc
 
 	검색결과_목록_메인 aggregationSearch(Query query) ;
 
+	검색결과_목록_메인 aggregationSearch(Query query, String newIndex) ;
+
     List<IndexedObjectInformation> bulkIndex(List<IndexQuery> indexQueryList);
 
     List<T> normalSearch(Query query);
+
+	List<T> normalSearch(Query query, String newIndex);
 
 	List<T>  getAllCreatedSince(Date date, Class<T> clazz);
 


### PR DESCRIPTION
RestHighLevelClient 사용하지 않고 jiraissue 백업인덱스로 조회 호출할 수 있도록 작업 및 소스 수정

1. aggregationSearch(Query query, String newIndex) - 다른인덱스로 집계조회 호출
2. normalSearch(Query query, String newIndex) - 다른인덱스로 조회 호출

현재 : 지라 이슈 인덱스 날짜 별 백업
-> 지라이슈 백업인덱스에 Document ID와 날짜가 들어가도록 하여 백업으로 변경 작업 테스트 코드

#close #time 1h +review SR @313devops

[ Backend-Core::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/