### PR TITLE
:see_no_evil: refactor: [Engine] #comment 레드마인 이슈 해결책 - 24.03.31

### DIFF
--- a/src/main/java/com/arms/api/alm/issueresolution/service/이슈해결책_전략_호출.java
+++ b/src/main/java/com/arms/api/alm/issueresolution/service/이슈해결책_전략_호출.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -76,7 +77,7 @@ public class 이슈해결책_전략_호출 {
 
         if (서버_유형 == 서버유형_정보.레드마인_온프레미스) {
             로그.info("레드마인 온프레미스 타입은 이슈 해결책을 지원하지 않습니다.");
-            return null;
+            return Collections.emptyList();
         }
 
         이슈해결책_전략_등록_및_실행 = 지라이슈해결책_전략_확인(연결정보);


### PR DESCRIPTION
레드마인 서버는 이슈 해결책 미지원 시 null이 아닌 emptyList 처리

#close #time 1h +review SR @313devops

[ Engine-Fire::Java-Service-Tree-Framework(JSTF)::Advanc2d ] [Requirement Manage] http://www.a-rms.net
[Document] http://www.313.co.kr/confluence
[IssueTracker] http://www.313.co.kr/jira
[VersionControl] https://github.com/313devgrp
[CodeReview] http://www.313.co.kr/fecru
[CICD-Deploy] http://www.313.co.kr/jenkins
[BuildManager] http://www.313.co.kr/spinnaker
[ArtifactManager] http://www.313.co.kr/nexus
[CodeAnalysis] http://www.313.co.kr/sonar
[Docker Hub] https://hub.docker.com/u/313devgrp

[Kubernetes] http://www.313.co.kr:31380
[DockerSwarm] http://www.313.co.kr/portainer/#!/auth

[DB Admin] http://www.313.co.kr/phpmyadmin/
[S3 Admin] http://www.313.co.kr/minio/login
[MEM Admin] http://www.313.co.kr/redis/
[NoSql Index] http://www.313.co.kr/elasticsearch/_cat/indices [NoSql Node] http://www.313.co.kr/elasticsearch/_nodes?pretty=true [Kibana] http://www.313.co.kr/kibana/app/home#/
[LogStash] http://www.313.co.kr/logstash/_node/stats?pretty [ZipKin] http://www.313.co.kr/zipkin/
[ElasticHQ] http://www.313.co.kr/elastichq/#!/
[Grafana] http://www.313.co.kr/grafana

[NAS] http://www.313.co.kr:5000/webman/index.cgi
[Mail] http://www.313.co.kr/mail/
[Auth] http://www.313.co.kr/auth/
[RDP] http://www.313.co.kr/guacamole/#/